### PR TITLE
feature/train-movement: 電車移動ロジック + 駅間移動実装

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
-
 plugins {
     kotlin("jvm") version "1.9.0"
     id("com.github.johnrengelman.shadow") version "7.1.2"
+    id("org.jlleitschuh.gradle.ktlint") version "11.6.1"
 }
 
 group = "com.woxloi"

--- a/src/main/kotlin/com/woxloi/trainplugin/command/TrainCommand.kt
+++ b/src/main/kotlin/com/woxloi/trainplugin/command/TrainCommand.kt
@@ -3,6 +3,7 @@ package com.woxloi.trainplugin.command
 import com.woxloi.trainplugin.TrainPlugin
 import com.woxloi.trainplugin.station.StationManager
 import com.woxloi.trainplugin.train.Route
+import com.woxloi.trainplugin.train.RouteManager
 import com.woxloi.trainplugin.train.Train
 import com.woxloi.trainplugin.train.TrainManager
 import org.bukkit.command.Command
@@ -19,7 +20,7 @@ class TrainCommand : CommandExecutor {
         args: Array<out String>
     ): Boolean {
         if (args.isEmpty()) {
-            sender.sendMessage("${TrainPlugin.prefix}使い方: /train <start|stop|info>")
+            sender.sendMessage("${TrainPlugin.prefix}使い方: /train <start|stop|info|route>")
             return true
         }
 
@@ -31,19 +32,20 @@ class TrainCommand : CommandExecutor {
                 }
 
                 val id = args.getOrNull(1) ?: "default"
-                val stations = StationManager.listStations()
-                if (stations.size < 2) {
-                    sender.sendMessage("${TrainPlugin.prefix}駅が2つ以上必要です")
+                val routeName = args.getOrNull(2) ?: "main"
+
+                val route = RouteManager.getRoute(routeName)
+                if (route == null || route.size() < 2) {
+                    sender.sendMessage("${TrainPlugin.prefix}ルート $routeName が存在しないか、駅が2つ以上必要です")
                     return true
                 }
 
-                val route = Route(stations.toList())
                 val train = Train(id, route)
-                train.spawn(stations.first())
+                train.spawn(route.getStationAt(0)!!)
                 train.start()
                 TrainManager.addTrain(train)
 
-                sender.sendMessage("${TrainPlugin.prefix}電車 $id を出発させました")
+                sender.sendMessage("${TrainPlugin.prefix}電車 $id をルート $routeName で出発させました")
             }
 
             "stop" -> {
@@ -56,6 +58,17 @@ class TrainCommand : CommandExecutor {
                 TrainManager.listTrains().forEach {
                     sender.sendMessage("${TrainPlugin.prefix}${it.info()}")
                 }
+            }
+
+            "route" -> {
+                val stations = StationManager.listStations().toList()
+                if (stations.size < 2) {
+                    sender.sendMessage("${TrainPlugin.prefix}駅が2つ以上必要です")
+                    return true
+                }
+                val route = Route("main", stations.toMutableList())
+                RouteManager.addRoute(route)
+                sender.sendMessage("${TrainPlugin.prefix}ルート main を登録しました (駅数=${stations.size})")
             }
 
             else -> sender.sendMessage("${TrainPlugin.prefix}不明なサブコマンドです")

--- a/src/main/kotlin/com/woxloi/trainplugin/train/Route.kt
+++ b/src/main/kotlin/com/woxloi/trainplugin/train/Route.kt
@@ -2,4 +2,23 @@ package com.woxloi.trainplugin.train
 
 import com.woxloi.trainplugin.station.Station
 
-data class Route(val stations: List<Station>)
+data class Route(
+    val name: String,
+    private val stations: MutableList<Station> = mutableListOf()
+) {
+
+    fun addStation(station: Station) {
+        stations.add(station)
+    }
+
+    fun removeStation(station: Station) {
+        stations.remove(station)
+    }
+
+    fun getStations(): List<Station> = stations.toList()
+
+    fun size(): Int = stations.size
+
+    fun getStationAt(index: Int): Station? =
+        if (index in stations.indices) stations[index] else null
+}

--- a/src/main/kotlin/com/woxloi/trainplugin/train/RouteManager.kt
+++ b/src/main/kotlin/com/woxloi/trainplugin/train/RouteManager.kt
@@ -1,0 +1,17 @@
+package com.woxloi.trainplugin.train
+
+object RouteManager {
+    private val routes = mutableMapOf<String, Route>()
+
+    fun addRoute(route: Route) {
+        routes[route.name] = route
+    }
+
+    fun getRoute(name: String): Route? = routes[name]
+
+    fun removeRoute(name: String) {
+        routes.remove(name)
+    }
+
+    fun listRoutes(): Collection<Route> = routes.values
+}

--- a/src/main/kotlin/com/woxloi/trainplugin/train/Train.kt
+++ b/src/main/kotlin/com/woxloi/trainplugin/train/Train.kt
@@ -33,36 +33,40 @@ class Train(
 
     private fun moveToNextStation() {
         if (!running || entity == null) return
+        if (route.size() < 2) return
 
-        val next = route.stations[(index + 1) % route.stations.size]
+        val next = route.getStationAt((index + 1) % route.size())!!
         val world = Bukkit.getWorld(next.world) ?: return
         val target = Location(world, next.x, next.y, next.z)
 
-        val steps = 40 // 2秒くらいで到着
+        val steps = 40
         val current = entity!!.location.clone()
         val dx = (target.x - current.x) / steps
         val dy = (target.y - current.y) / steps
         val dz = (target.z - current.z) / steps
 
         var count = 0
-        val task = Bukkit.getScheduler().runTaskTimer(
+        lateinit var task: org.bukkit.scheduler.BukkitTask
+
+        task = Bukkit.getScheduler().runTaskTimer(
             Bukkit.getPluginManager().getPlugin("TrainPlugin")!!,
             Runnable {
                 if (!running || entity == null) return@Runnable
+
                 if (count >= steps) {
                     entity!!.teleport(target)
-                    index = (index + 1) % route.stations.size
+                    index = (index + 1) % route.size()
                     Bukkit.getLogger().info("Train $id が駅 ${next.name} に到着しました")
 
-                    // 停車後に次の駅へ
                     Bukkit.getScheduler().runTaskLater(
                         Bukkit.getPluginManager().getPlugin("TrainPlugin")!!,
                         Runnable { if (running) moveToNextStation() },
-                        40L // 2秒停車
+                        40L
                     )
-                    task.cancel()
+                    task.cancel() // ここでキャンセル可能
                     return@Runnable
                 }
+
                 val loc = entity!!.location.clone().add(dx, dy, dz)
                 entity!!.teleport(loc)
                 count++
@@ -76,7 +80,7 @@ class Train(
     }
 
     fun info(): String {
-        val current = route.stations[index]
-        return "Train-$id: 現在地=${current.name}, 停止中=${!running}"
+        val current = route.getStationAt(index)
+        return "Train-$id: 現在地=${current?.name ?: "不明"}, 停止中=${!running}"
     }
 }


### PR DESCRIPTION
## 概要
TrainPlugin における電車の移動ロジックと駅間移動の実装を追加しました。

## 内容
- Train クラスで駅間の移動処理を実装
- Route クラスで駅のルート管理
- TrainManager で電車の管理
- /train コマンドで電車の start/stop/info が使用可能に

## 確認方法
1. サーバーを起動
2. /station で駅を2つ以上作成
3. /train start で電車を出発
4. /train info で現在の駅と停止状態を確認
5. /train stop で電車を停止

## 注意点
- 現状は1列車のみのルートを想定
- 移動は ArmorStand を使用した簡易表現
